### PR TITLE
External resource file

### DIFF
--- a/assets/pyinstaller.spec
+++ b/assets/pyinstaller.spec
@@ -17,7 +17,16 @@ a = Analysis(
     pathex=[],
     binaries=[],
     # https://pyinstaller.org/en/stable/spec-files.html#adding-data-files
-    datas=[(str(APP_MANIFEST_FILE), str(ASSETS_DIR.relative_to(PROJECT_ROOT)))],
+    datas=[
+        (
+            str(APP_MANIFEST_FILE),
+            str(ASSETS_DIR.relative_to(PROJECT_ROOT)),
+        ),
+        (
+            str(ASSETS_DIR / 'images' / 'button.gif'),
+            str(ASSETS_DIR.relative_to(PROJECT_ROOT) / 'images'),
+        ),
+    ],
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -82,7 +82,7 @@ everywhere.
 
 They are converted to `.py` using `pyside6-rcc`. Binaries included as a binary string.
 
-Notes:
+**Notes:**
 
 * The `.py` resource files should have `_rc` appended in the name.  
   Ex, `user_form.qrc` should be converted to `user_form_rc.py`.
@@ -94,11 +94,13 @@ Notes:
   same and everything is similar.  
   In Qt Creator there's the concept of _Project_ and the resource file needs to first be associated
   with the project to then be used in the `.ui` file.
+* The file `assets/images/button.gif` is included in the app as an external resource file for demo
+  purposes.
   
 !!! Note
 
     SVG files may not work on some machines if the required dependencies are not installed.  
-    For that reason, working only with PNG, ICO and JPG files.
+    For that reason, working only with PNG, ICO, GIF and JPG files.
 
     For a list of supported formats in the current machine:
 

--- a/src/ui/playground_main_window.py
+++ b/src/ui/playground_main_window.py
@@ -48,7 +48,11 @@ class PlaygroundMainWindow(QMainWindow, Ui_PlaygroundMainWindow):
         print(result)
 
     def show_animation(self):
-        dialog = AnimationDialog(config.ASSETS_DIR / 'images' / 'button.gif')
+        # This `.gif` file is not bundled in the resources like the other images.
+        # It is added as a separate file with the executable for demo purposes (how to include an
+        # external resource in the app).
+        gif_path = config.ASSETS_DIR / 'images' / 'button.gif'
+        dialog = AnimationDialog(gif_path)
         dialog.exec()
 
     # noinspection PyMethodMayBeStatic

--- a/tasks.py
+++ b/tasks.py
@@ -366,7 +366,8 @@ def build_run(c):
             raise Exit('Multiple executables found.')
         c.run(str(exes[0]))
     elif os_name == 'mac':
-        raise Exit('Running on MacOS still needs to be implemented.')
+        app_file, _, _ = _get_build_files()
+        c.run(str(app_file))
     elif os_name == 'linux':
         raise Exit('Running on Linux still needs to be implemented.')
     else:


### PR DESCRIPTION
Using a file (`assets/images/button.gif`) as an external resource bundled with the app, as opposed to being included in `resources.qrc`.